### PR TITLE
Issue 5 sendemailasync

### DIFF
--- a/Mailer.NET.sln
+++ b/Mailer.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailer.NET", "Mailer.NET\Mailer.NET.csproj", "{2F995553-8522-456F-88D6-156BC9DE1638}"
 EndProject
@@ -20,12 +20,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2F995553-8522-456F-88D6-156BC9DE1638}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{2F995553-8522-456F-88D6-156BC9DE1638}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{2F995553-8522-456F-88D6-156BC9DE1638}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F995553-8522-456F-88D6-156BC9DE1638}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F995553-8522-456F-88D6-156BC9DE1638}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F995553-8522-456F-88D6-156BC9DE1638}.Release|Any CPU.Build.0 = Release|Any CPU
-		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{673F7CA1-2743-4E19-822A-29B57799F6B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/Mailer.NET/Mailer.NET.csproj
+++ b/Mailer.NET/Mailer.NET.csproj
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
     <ProjectGuid>{2F995553-8522-456F-88D6-156BC9DE1638}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,9 +14,11 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NugetDirectory>net45</NugetDirectory>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\$(Configuration)\$(TargetFrameworkVersion)\</OutputPath>
+    <ProjectGuid>{2F995553-8522-456F-88D6-156BC9DE1638}</ProjectGuid>
     <DefineConstants>TRACE;</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
@@ -26,6 +27,10 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NugetDirectory>net45</NugetDirectory>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mailer.NET</RootNamespace>
+    <AssemblyName>Mailer.NET</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NVelocity">
@@ -33,9 +38,6 @@
     </Reference>
     <Reference Include="RestSharp" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="RestSharp" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Mailer.NET/Mailer/Transport/AbstractTransport.cs
+++ b/Mailer.NET/Mailer/Transport/AbstractTransport.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading.Tasks;
 using Mailer.NET.Mailer.Response;
 
 namespace Mailer.NET.Mailer.Transport
@@ -7,5 +8,6 @@ namespace Mailer.NET.Mailer.Transport
     {
         public WebProxy Proxy { get; set; }
         public abstract EmailResponse SendEmail(Email email);
+        public abstract Task<EmailResponse> SendEmailAsync(Email email);
     }
 }

--- a/Mailer.NET/Mailer/Transport/DebugTransport.cs
+++ b/Mailer.NET/Mailer/Transport/DebugTransport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Mailer.NET.Mailer.Response;
 
 namespace Mailer.NET.Mailer.Transport
@@ -15,14 +16,25 @@ namespace Mailer.NET.Mailer.Transport
             Success = success;
         }
 
-        public override Response.EmailResponse SendEmail(Email email)
+        public override EmailResponse SendEmail(Email email)
         {
-            var response = new EmailResponse()
+            var response = GenerateDebugEmailResponse();
+            return response;
+        }
+
+        public override async Task<EmailResponse> SendEmailAsync(Email email)
+        {
+            var response = await Task.FromResult(GenerateDebugEmailResponse());
+            return response;
+        }
+
+        private EmailResponse GenerateDebugEmailResponse()
+        {
+            return new EmailResponse
             {
                 Success = Success,
                 Message = (Success ? "Email successfully sent" : "Undefined Error")
             };
-            return response;
         }
     }
 }

--- a/Mailer.NET/Mailer/Transport/SmtpTransport.cs
+++ b/Mailer.NET/Mailer/Transport/SmtpTransport.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Mail;
 using System.Net.Mime;
-using System.Text;
 using System.Threading.Tasks;
 using Mailer.NET.Mailer.Response;
 
 namespace Mailer.NET.Mailer.Transport
 {
-    public class SmtpTransport:AbstractTransport
+    public class SmtpTransport : AbstractTransport
     {
         public string Host { get; set; }
         public int Port { get; set; }
@@ -19,8 +16,8 @@ namespace Mailer.NET.Mailer.Transport
 
         public SmtpTransport()
         {
-            
         }
+
         public SmtpTransport(string host, int port, string user, string password, bool ssl)
         {
             Host = host;
@@ -32,85 +29,11 @@ namespace Mailer.NET.Mailer.Transport
 
         public override EmailResponse SendEmail(Email email)
         {
-            using (MailMessage mail = new MailMessage())
+            var mail = GenerateMailMessage(email);
+            var emailResponse = new EmailResponse();
+
+            using (var objSmtp = GenerateSmtpClient())
             {
-                mail.From = new MailAddress(email.From.Email, email.From.Name);
-
-                if (email.To != null)
-                {
-                    email.To.ForEach(delegate (Contact address)
-                    {
-                        mail.To.Add(new MailAddress(address.Email, address.Name));
-                    });
-                }
-                    
-                if(email.Bco != null)
-                {
-                    email.Bco.ForEach(delegate (Contact address)
-                    {
-                        mail.To.Add(new MailAddress(address.Email, address.Name));
-                    });
-                }
-
-                if (email.Cco != null)
-                {
-                    email.Cco.ForEach(delegate (Contact address)
-                    {
-                        mail.To.Add(new MailAddress(address.Email, address.Name));
-                    });
-                }
-
-                var avHtml = AlternateView.CreateAlternateViewFromString(email.Message, null, MediaTypeNames.Text.Html);
-
-                if (email.Attachments != null)
-                {
-                    foreach (var attachment in email.Attachments)
-                    {
-                        
-                        if (!string.IsNullOrEmpty(attachment.ContentId))
-                        {
-                            var inline = new LinkedResource(attachment.File, attachment.MimeType)
-                            {
-                                ContentId = attachment.ContentId
-                            };
-                            avHtml.LinkedResources.Add(inline);
-                        }
-                        else
-                        {
-                            var anexo = new System.Net.Mail.Attachment(attachment.File, attachment.MimeType);
-                            mail.Attachments.Add(anexo);
-                        }
-                    }
-
-                    mail.AlternateViews.Add(avHtml);
-                }
-
-                mail.IsBodyHtml = email.Type == EmailContentType.Html;
-                mail.Subject = email.Subject;
-                mail.Body = email.Message;
-
-                if (email.HasReadNotification)
-                {
-                    mail.Headers.Add("Disposition-Notification-To", email.From.Email);
-                }
-
-                if (!String.IsNullOrEmpty(email.ReplyTo))
-                {
-                    mail.ReplyToList.Add(email.ReplyTo);
-                }
-
-                var objSmtp = new System.Net.Mail.SmtpClient
-                {
-                    UseDefaultCredentials = false,
-                    Credentials = new System.Net.NetworkCredential(User, Password),
-                    DeliveryMethod = SmtpDeliveryMethod.Network,
-                    Host = Host,
-                    Port = Port,
-                    EnableSsl = Ssl
-                };
-
-                EmailResponse emailResponse = new EmailResponse();
-
                 try
                 {
                     objSmtp.Send(mail);
@@ -122,8 +45,119 @@ namespace Mailer.NET.Mailer.Transport
                     emailResponse.Success = false;
                     emailResponse.Message = erro.Message;
                 }
-                return emailResponse;
             }
+
+            mail.Dispose();
+            return emailResponse;
+        }
+
+        public override async Task<EmailResponse> SendEmailAsync(Email email)
+        {
+            var mail = GenerateMailMessage(email);
+            var emailResponse = new EmailResponse();
+
+            using (var objSmtp = GenerateSmtpClient())
+            {
+                try
+                {
+                    await objSmtp.SendMailAsync(mail);
+                    emailResponse.Success = true;
+                    emailResponse.Message = "Email successfully sent";
+                }
+                catch (Exception erro)
+                {
+                    emailResponse.Success = false;
+                    emailResponse.Message = erro.Message;
+                }
+            }
+
+            mail.Dispose();
+            return emailResponse;
+        }
+
+        private SmtpClient GenerateSmtpClient()
+        {
+            var objSmtp = new System.Net.Mail.SmtpClient
+            {
+                UseDefaultCredentials = false,
+                Credentials = new System.Net.NetworkCredential(User, Password),
+                DeliveryMethod = SmtpDeliveryMethod.Network,
+                Host = Host,
+                Port = Port,
+                EnableSsl = Ssl
+            };
+            return objSmtp;
+        }
+
+        private MailMessage GenerateMailMessage(Email email)
+        {
+            var mail = new MailMessage();
+            mail.From = new MailAddress(email.From.Email, email.From.Name);
+
+            if (email.To != null)
+            {
+                email.To.ForEach(delegate (Contact address)
+                {
+                    mail.To.Add(new MailAddress(address.Email, address.Name));
+                });
+            }
+
+            if (email.Bco != null)
+            {
+                email.Bco.ForEach(delegate (Contact address)
+                {
+                    mail.To.Add(new MailAddress(address.Email, address.Name));
+                });
+            }
+
+            if (email.Cco != null)
+            {
+                email.Cco.ForEach(delegate (Contact address)
+                {
+                    mail.To.Add(new MailAddress(address.Email, address.Name));
+                });
+            }
+
+            var avHtml = AlternateView.CreateAlternateViewFromString(email.Message, null, MediaTypeNames.Text.Html);
+
+            if (email.Attachments != null)
+            {
+                foreach (var attachment in email.Attachments)
+                {
+
+                    if (!string.IsNullOrEmpty(attachment.ContentId))
+                    {
+                        var inline = new LinkedResource(attachment.File, attachment.MimeType)
+                        {
+                            ContentId = attachment.ContentId
+                        };
+                        avHtml.LinkedResources.Add(inline);
+                    }
+                    else
+                    {
+                        var anexo = new System.Net.Mail.Attachment(attachment.File, attachment.MimeType);
+                        mail.Attachments.Add(anexo);
+                    }
+                }
+
+                mail.AlternateViews.Add(avHtml);
+            }
+
+            mail.IsBodyHtml = email.Type == EmailContentType.Html;
+            mail.Subject = email.Subject;
+            mail.Body = email.Message;
+
+            if (email.HasReadNotification)
+            {
+                mail.Headers.Add("Disposition-Notification-To", email.From.Email);
+            }
+
+            if (!String.IsNullOrEmpty(email.ReplyTo))
+            {
+                mail.ReplyToList.Add(email.ReplyTo);
+            }
+
+            return mail;
         }
     }
 }

--- a/SendEmailTest/SendEmailTest.csproj
+++ b/SendEmailTest/SendEmailTest.csproj
@@ -1,59 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">DebugNET40</Configuration>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{673F7CA1-2743-4E19-822A-29B57799F6B1}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SendEmailTest</RootNamespace>
     <AssemblyName>SendEmailTest</AssemblyName>
-	<TargetFrameworkVersion Condition=" '$(Configuration)' == 'DebugNET45' ">v4.5</TargetFrameworkVersion>
-	<TargetFrameworkVersion Condition=" '$(Configuration)' == 'DebugNET40' ">v4.0</TargetFrameworkVersion>
-	<TargetFrameworkVersion Condition=" '$(Configuration)' == 'ReleaseNET45' ">v4.5</TargetFrameworkVersion>
-	<TargetFrameworkVersion Condition=" '$(Configuration)' == 'ReleaseNET40' ">v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <OutputPath>bin\Debug\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugNET40|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\DebugNET40\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SendEmailTest</RootNamespace>
+    <AssemblyName>SendEmailTest</AssemblyName>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugNET45|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\DebugNET45\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseNET45|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\ReleaseNET45\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseNET40|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\ReleaseNET40\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup>
+    <ProjectGuid>{673F7CA1-2743-4E19-822A-29B57799F6B1}</ProjectGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/buildall.bat
+++ b/buildall.bat
@@ -2,7 +2,7 @@ REM Build Mailer.NET
 SET CONFIGURATION=%1
 set PATH_SOURCE_SLN="%cd%\Mailer.NET.sln"
 if [%1]==[] (
-  SET CONFIGURATION=DebugNET40
+  SET CONFIGURATION=Debug
 )
 MSBuild %PATH_SOURCE_SLN% /p:Configuration=%CONFIGURATION%
 

--- a/create-nuget.bat
+++ b/create-nuget.bat
@@ -2,9 +2,7 @@
 SET HOME=%cd%
 
 cd "%HOME%"
-call buildall.bat ReleaseNET40
-cd "%HOME%"
-call buildall.bat ReleaseNET45
+call buildall.bat Release
 cd "%HOME%\Mailer.NET"
 "%HOME%\.nuget\NuGet.exe" Pack "%HOME%\Mailer.NET\Mailer.NET.csproj"
 


### PR DESCRIPTION
Implementation for SendEmailAsync for all transport types.  Refactored client / request / response logic into common private methods since it's shared between async and non-async implementations.  .NET 4.0 configuration no longer builds because async/await keywords require 4.5+.